### PR TITLE
Fixes problem with a private user when creating records in admin dashboard concerning the action log -class' validations

### DIFF
--- a/app/models/concerns/decidim/apiext/action_log_extensions.rb
+++ b/app/models/concerns/decidim/apiext/action_log_extensions.rb
@@ -6,7 +6,11 @@ module Decidim
       extend ActiveSupport::Concern
 
       included do
-        belongs_to :user, polymorphic: true
+        if Decidim.module_installed? :privacy
+          belongs_to :user, -> { entire_collection }, polymorphic: true
+        else
+          belongs_to :user, polymorphic: true
+        end
       end
     end
   end


### PR DESCRIPTION
# Action log validation fix to find private users
## Description
Adds the "entire_collection" -scope for Action log -class' user association to allow the validation to find private users.

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Category subject
  1. action_log_extensions.rb
     * Belongs_to association was updated for the user -class. This update allows the association to use the entire user database instead of only the public ones if the "Decidim-Privacy" -module is used. If however the "Decidim-Privacy" -module is not used, the action_log user association is used "normally" without any scoping.
     
     Before this update the limited list for the association prevented private admin users to create any new records in the admin dashboard. For example creating a new process or process phases wasn't possible with a private user.